### PR TITLE
Show the action bar initially so the status bar does not show white

### DIFF
--- a/app/main.aot.ts
+++ b/app/main.aot.ts
@@ -3,4 +3,4 @@ import { platformNativeScript } from "nativescript-angular/platform-static";
 
 import { AppModuleNgFactory } from "./app.module.ngfactory";
 
-platformNativeScript().bootstrapModuleFactory(AppModuleNgFactory);
+platformNativeScript({ startPageActionBarHidden: false }).bootstrapModuleFactory(AppModuleNgFactory);

--- a/app/main.ts
+++ b/app/main.ts
@@ -4,4 +4,4 @@ import {registerElement} from "nativescript-angular/element-registry";
 import { AppModule } from "./app.module";
 
 //registerElement("PlayPause", () => require("nativescript-play-pause-button").PlayPauseButton);
-platformNativeScriptDynamic().bootstrapModule(AppModule);
+platformNativeScriptDynamic({ startPageActionBarHidden: false }).bootstrapModule(AppModule);


### PR DESCRIPTION
A final touch.
Angular apps seem to bootstrap as web apps and does chain several promises before they make the UI, so they fail to provide the content in viewWillAppear for iOS and the page renders without content initially. It takes some time for the action bar to be created and added to the page.